### PR TITLE
Introduce lib-ijson 0.1.3 to the benchmark 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,16 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde-bench = { version = "0.0.7", optional = true }
 serde_json = { version = "1.0", optional = true }
 simd-json = { version = "0.1", optional = true}
+ijson = { version = "0.1.3", optional = true}
 time = "0.1"
 
 [features]
 default = ["performance", "all-libs", "all-files"]
-all-libs = ["lib-serde", "lib-json-rust", "lib-rustc-serialize", "lib-simd-json"]
+all-libs = ["lib-serde", "lib-ijson", "lib-json-rust", "lib-rustc-serialize", "lib-simd-json"]
 all-files = ["file-canada", "file-citm-catalog", "file-twitter"]
 performance = ["parse-dom", "stringify-dom", "parse-struct", "stringify-struct"]
 lib-serde = ["serde", "serde_json"]
+lib-ijson = ["serde", "ijson"]
 lib-simd-json = ["serde", "simd-json"]
 lib-json-rust = ["json"]
 lib-rustc-serialize = ["rustc-serialize"]

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ This is a partial port of [nativejson-benchmark] to Rust. The libraries tested
 are:
 
 - [serde\_json] 1.0.53
+- [ijson] 0.1.3
 - [json-rust] 0.12.4
 - [rustc-serialize] 0.3.24
 - [simd-json] 0.1.26 (this requires a modern x86 CPU for good results)
 
 [nativejson-benchmark]: https://github.com/miloyip/nativejson-benchmark
 [serde\_json]: https://github.com/serde-rs/json
+[serde\_json with ijson's IValue]: https://github.com/serde-rs/json + https://github.com/Diggsey/ijson
 [json-rust]: https://github.com/maciejhirsz/json-rust
 [rustc-serialize]: https://github.com/rust-lang-nursery/rustc-serialize
 [simd-json]: https://github.com/Licenser/simdjson-rs
@@ -17,30 +19,35 @@ are:
 #### `$ cargo run --release`
 
 ```
-                                DOM                STRUCT
+                                DOM                  STRUCT
 ======= serde_json ======= parse|stringify ===== parse|stringify ====
-data/canada.json         280 MB/s   370 MB/s   510 MB/s   320 MB/s
-data/citm_catalog.json   400 MB/s   420 MB/s   840 MB/s   660 MB/s
-data/twitter.json        270 MB/s   730 MB/s   530 MB/s   850 MB/s
+data/canada.json         320 MB/s   490 MB/s   530 MB/s   370 MB/s
+data/citm_catalog.json   410 MB/s   590 MB/s   760 MB/s   910 MB/s
+data/twitter.json        290 MB/s   820 MB/s   590 MB/s  1070 MB/s
+
+========= ijson ========== parse|stringify ===== parse|stringify ====
+data/canada.json         260 MB/s   420 MB/s
+data/citm_catalog.json   330 MB/s   560 MB/s
+data/twitter.json        210 MB/s   870 MB/s
 
 ======= json-rust ======== parse|stringify ===== parse|stringify ====
-data/canada.json         270 MB/s   830 MB/s
-data/citm_catalog.json   550 MB/s   700 MB/s
-data/twitter.json        410 MB/s   900 MB/s
+data/canada.json         370 MB/s  1010 MB/s
+data/citm_catalog.json   620 MB/s   900 MB/s
+data/twitter.json        470 MB/s  1120 MB/s
 
 ==== rustc_serialize ===== parse|stringify ===== parse|stringify ====
-data/canada.json         150 MB/s    65 MB/s   110 MB/s    45 MB/s
-data/citm_catalog.json   180 MB/s   180 MB/s   130 MB/s   210 MB/s
-data/twitter.json         99 MB/s   320 MB/s    75 MB/s   350 MB/s
+data/canada.json         180 MB/s    78 MB/s   140 MB/s    53 MB/s
+data/citm_catalog.json   220 MB/s   210 MB/s   160 MB/s   240 MB/s
+data/twitter.json        130 MB/s   360 MB/s    94 MB/s   400 MB/s
 
 ======= simd-json ======== parse|stringify ===== parse|stringify ====
-data/canada.json         350 MB/s   420 MB/s   580 MB/s
-data/citm_catalog.json   820 MB/s   590 MB/s  1290 MB/s
-data/twitter.json        660 MB/s   740 MB/s   900 MB/s
+data/canada.json         400 MB/s   530 MB/s   670 MB/s
+data/citm_catalog.json   910 MB/s   760 MB/s  1590 MB/s
+data/twitter.json        890 MB/s   870 MB/s  1080 MB/s
 ```
 
-- Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz *(laptop CPU from 2015)*
-- rustc 1.46.0-nightly (118b50524 2020-06-06)
+- Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz *(20-core x86 high performance server)*
+- rustc 1.56.0-nightly (2827db2b1 2021-08-01)
 
 To update the numbers above, I run `./json-benchmark` twice on an otherwise idle
 computer and take the greater of the two results for each number.

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,17 @@ fn main() {
         stringify_struct: serde_json::to_writer,
     }
 
+    #[cfg(feature = "ijson")]
+    bench! {
+        name: "ijson",
+        bench: bench_file,
+        dom: ijson::IValue,
+        parse_dom: ijson_parse_dom,
+        stringify_dom: serde_json::to_writer,
+        parse_struct: ijson_parse_struct,
+        stringify_struct: serde_json::to_writer,
+    }
+
     #[cfg(feature = "lib-json-rust")]
     bench! {
         name: "json-rust",
@@ -236,6 +247,16 @@ fn main() {
 }
 
 #[cfg(all(
+    feature = "ijson",
+    any(feature = "parse-dom", feature = "stringify-dom")
+))]
+fn ijson_parse_dom(bytes: &[u8]) -> serde_json::Result<ijson::IValue> {
+    use std::str;
+    let s = str::from_utf8(bytes).unwrap();
+    serde_json::from_str(s)
+}
+
+#[cfg(all(
     feature = "lib-serde",
     any(feature = "parse-dom", feature = "stringify-dom")
 ))]
@@ -250,6 +271,19 @@ fn serde_json_parse_dom(bytes: &[u8]) -> serde_json::Result<serde_json::Value> {
     any(feature = "parse-struct", feature = "stringify-struct")
 ))]
 fn serde_json_parse_struct<'de, T>(bytes: &'de [u8]) -> serde_json::Result<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    use std::str;
+    let s = str::from_utf8(bytes).unwrap();
+    serde_json::from_str(s)
+}
+
+#[cfg(all(
+    feature = "ijson",
+    any(feature = "parse-struct", feature = "stringify-struct")
+))]
+fn ijson_parse_struct<'de, T>(bytes: &'de [u8]) -> serde_json::Result<T>
 where
     T: serde::Deserialize<'de>,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,8 +215,6 @@ fn main() {
         dom: ijson::IValue,
         parse_dom: ijson_parse_dom,
         stringify_dom: serde_json::to_writer,
-        parse_struct: ijson_parse_struct,
-        stringify_struct: serde_json::to_writer,
     }
 
     #[cfg(feature = "lib-json-rust")]
@@ -271,19 +269,6 @@ fn serde_json_parse_dom(bytes: &[u8]) -> serde_json::Result<serde_json::Value> {
     any(feature = "parse-struct", feature = "stringify-struct")
 ))]
 fn serde_json_parse_struct<'de, T>(bytes: &'de [u8]) -> serde_json::Result<T>
-where
-    T: serde::Deserialize<'de>,
-{
-    use std::str;
-    let s = str::from_utf8(bytes).unwrap();
-    serde_json::from_str(s)
-}
-
-#[cfg(all(
-    feature = "ijson",
-    any(feature = "parse-struct", feature = "stringify-struct")
-))]
-fn ijson_parse_struct<'de, T>(bytes: &'de [u8]) -> serde_json::Result<T>
 where
     T: serde::Deserialize<'de>,
 {


### PR DESCRIPTION
Given the following crate https://github.com/Diggsey/ijson, we've added the serde_json variant that replaces serde-json's Value type with ijson's IValue.

The Readme results have been updated accordingly:

```
                                DOM                  STRUCT
======= serde_json ======= parse|stringify ===== parse|stringify ====
data/canada.json         320 MB/s   490 MB/s   530 MB/s   370 MB/s
data/citm_catalog.json   410 MB/s   590 MB/s   760 MB/s   910 MB/s
data/twitter.json        290 MB/s   820 MB/s   590 MB/s  1070 MB/s

========= ijson ========== parse|stringify ===== parse|stringify ====
data/canada.json         260 MB/s   420 MB/s
data/citm_catalog.json   330 MB/s   560 MB/s
data/twitter.json        210 MB/s   870 MB/s

======= json-rust ======== parse|stringify ===== parse|stringify ====
data/canada.json         370 MB/s  1010 MB/s
data/citm_catalog.json   620 MB/s   900 MB/s
data/twitter.json        470 MB/s  1120 MB/s

==== rustc_serialize ===== parse|stringify ===== parse|stringify ====
data/canada.json         180 MB/s    78 MB/s   140 MB/s    53 MB/s
data/citm_catalog.json   220 MB/s   210 MB/s   160 MB/s   240 MB/s
data/twitter.json        130 MB/s   360 MB/s    94 MB/s   400 MB/s

======= simd-json ======== parse|stringify ===== parse|stringify ====
data/canada.json         400 MB/s   530 MB/s   670 MB/s
data/citm_catalog.json   910 MB/s   760 MB/s  1590 MB/s
data/twitter.json        890 MB/s   870 MB/s  1080 MB/s
```

- Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz *(20-core x86 high performance server)*
- rustc 1.56.0-nightly (2827db2b1 2021-08-01)