### PR TITLE
Remove json-rust from the suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 getopts = "0.2"
 jemallocator = "0.5"
-json = { version = "0.12", optional = true }
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
@@ -17,12 +16,11 @@ time = "0.3"
 
 [features]
 default = ["performance", "all-libs", "all-files"]
-all-libs = ["lib-serde", "lib-json-rust", "lib-rustc-serialize", "lib-simd-json"]
+all-libs = ["lib-serde", "lib-rustc-serialize", "lib-simd-json"]
 all-files = ["file-canada", "file-citm-catalog", "file-twitter"]
 performance = ["parse-dom", "stringify-dom", "parse-struct", "stringify-struct"]
 lib-serde = ["serde", "serde_json"]
 lib-simd-json = ["serde", "simd-json"]
-lib-json-rust = ["json"]
 lib-rustc-serialize = ["rustc-serialize"]
 file-canada = []
 file-citm-catalog = []

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ This is a partial port of [nativejson-benchmark] to Rust. The libraries tested
 are:
 
 - [serde\_json] 1.0.72
-- [json-rust] 0.12.4
 - [rustc-serialize] 0.3.24
 - [simd-json] 0.4.11 (this requires a modern x86 CPU for good results)
 
 [nativejson-benchmark]: https://github.com/miloyip/nativejson-benchmark
 [serde\_json]: https://github.com/serde-rs/json
-[json-rust]: https://github.com/maciejhirsz/json-rust
 [rustc-serialize]: https://github.com/rust-lang-nursery/rustc-serialize
 [simd-json]: https://github.com/Licenser/simdjson-rs
 
@@ -22,11 +20,6 @@ are:
 data/canada.json         320 MB/s   430 MB/s   580 MB/s   310 MB/s
 data/citm_catalog.json   420 MB/s   560 MB/s   710 MB/s   880 MB/s
 data/twitter.json        300 MB/s   910 MB/s   550 MB/s  1060 MB/s
-
-======= json-rust ======== parse|stringify ===== parse|stringify ====
-data/canada.json         390 MB/s   840 MB/s
-data/citm_catalog.json   520 MB/s   780 MB/s
-data/twitter.json        430 MB/s  1030 MB/s
 
 ==== rustc_serialize ===== parse|stringify ===== parse|stringify ====
 data/canada.json         150 MB/s    67 MB/s   120 MB/s    46 MB/s

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,15 +210,6 @@ fn main() {
         stringify_struct: serde_json::to_writer,
     }
 
-    #[cfg(feature = "lib-json-rust")]
-    bench! {
-        name: "json-rust",
-        bench: bench_file,
-        dom: json::JsonValue,
-        parse_dom: json_rust_parse_dom,
-        stringify_dom: json_rust_stringify_dom,
-    }
-
     #[cfg(feature = "lib-rustc-serialize")]
     bench! {
         name: "rustc_serialize",
@@ -258,21 +249,6 @@ where
     use std::str;
     let s = str::from_utf8(bytes).unwrap();
     serde_json::from_str(s)
-}
-
-#[cfg(all(
-    feature = "lib-json-rust",
-    any(feature = "parse-dom", feature = "stringify-dom")
-))]
-fn json_rust_parse_dom(bytes: &[u8]) -> json::Result<json::JsonValue> {
-    use std::str;
-    let s = str::from_utf8(bytes).unwrap();
-    json::parse(&s)
-}
-
-#[cfg(all(feature = "lib-json-rust", feature = "stringify-dom"))]
-fn json_rust_stringify_dom<W: io::Write>(write: &mut W, dom: &json::JsonValue) -> io::Result<()> {
-    dom.write(write)
 }
 
 #[cfg(all(


### PR DESCRIPTION
As per #21, the crate is currently unmaintained and may have undefined behavior. I did verify the suite still ran after these changes.

Closes #21.